### PR TITLE
Add Support for Optional "location" Element Under "configuration" Element

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ x64/
 *.ncrunchsolution
 *.ncrunchproject
 _NCrunch_WebCompiler
+/UpgradeLog.htm

--- a/WebDeployParametersToolkit.Tests/Properties/Resources.Designer.cs
+++ b/WebDeployParametersToolkit.Tests/Properties/Resources.Designer.cs
@@ -61,8 +61,13 @@ namespace WebDeployParametersToolkit.Tests.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to &lt;?xml version=&quot;1.0&quot; encoding=&quot;utf-8&quot; ?&gt; 
-        ///.
+        ///   Looks up a localized string similar to &lt;?xml version=&quot;1.0&quot; encoding=&quot;utf-8&quot; ?&gt;
+        ///&lt;parameters&gt;
+        ///	&lt;parameter defaultvalue=&quot;FirstValue&quot; description=&quot;Description of FirstParameter&quot; name=&quot;FirstParameter&quot;&gt;
+        ///		&lt;parameterentry kind=&quot;XmlFile&quot; match=&quot;/configuration/appSettings/add[@key=&apos;FirstAppSetting&apos;]/@value&quot; scope=&quot;\\web.config$&quot; /&gt;
+        ///	&lt;/parameter&gt;
+        ///	&lt;parameter defaultvalue=&quot;SecondValue&quot; description=&quot;Description of SecondParameter&quot; name=&quot;SecondParameter&quot;&gt;
+        ///		&lt;parameterentry kind=&quot;XmlFile&quot; match=&quot;/configuration/appSettings/add[@key=&apos;SecondAppSetting&apos;]/@v [rest of string was truncated]&quot;;.
         /// </summary>
         internal static string BasicParameters {
             get {
@@ -83,6 +88,22 @@ namespace WebDeployParametersToolkit.Tests.Properties {
         internal static string EmptySettings {
             get {
                 return ResourceManager.GetString("EmptySettings", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to &lt;?xml version=&quot;1.0&quot; encoding=&quot;utf-8&quot; ?&gt;
+        ///&lt;configuration&gt;
+        ///  &lt;configSections&gt;
+        ///    &lt;sectionGroup name=&quot;applicationSettings&quot; type=&quot;System.Configuration.ApplicationSettingsGroup, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089&quot;&gt;
+        ///      &lt;section name=&quot;TestApp.Properties.Settings&quot; type=&quot;System.Configuration.ClientSettingsSection, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089&quot; requirePermission=&quot;false&quot; /&gt;
+        ///    &lt;/sectionGroup&gt;
+        ///  &lt;/configSections&gt;
+        ///  &lt;location&gt; [rest of string was truncated]&quot;;.
+        /// </summary>
+        internal static string LocationSimpleSettings {
+            get {
+                return ResourceManager.GetString("LocationSimpleSettings", resourceCulture);
             }
         }
         

--- a/WebDeployParametersToolkit.Tests/Properties/Resources.resx
+++ b/WebDeployParametersToolkit.Tests/Properties/Resources.resx
@@ -127,4 +127,7 @@
   <data name="SimpleSettings" type="System.Resources.ResXFileRef, System.Windows.Forms">
     <value>..\resources\simplesettings.config;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;utf-8</value>
   </data>
+  <data name="LocationSimpleSettings" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\resources\locationsimplesettings.config;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;utf-8</value>
+  </data>
 </root>

--- a/WebDeployParametersToolkit.Tests/Resources/LocationSimpleSettings.config
+++ b/WebDeployParametersToolkit.Tests/Resources/LocationSimpleSettings.config
@@ -1,0 +1,49 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<configuration>
+  <configSections>
+    <sectionGroup name="applicationSettings" type="System.Configuration.ApplicationSettingsGroup, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+      <section name="TestApp.Properties.Settings" type="System.Configuration.ClientSettingsSection, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" requirePermission="false" />
+    </sectionGroup>
+  </configSections>
+  <location>
+    <appSettings>
+      <add key="AppSettingsKey" value="0123" />
+    </appSettings>
+    <applicationSettings>
+      <TestApp.Properties.Settings>
+        <setting name="SomeString" serializeAs="String">
+          <value>String value is here.</value>
+        </setting>
+        <setting name="SomeBoolean" serializeAs="String">
+          <value>True</value>
+        </setting>
+        <setting name="SomeStringColletion" serializeAs="Xml">
+          <value>
+            <ArrayOfString xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+              xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+              <string>1 here</string>
+              <string>And other here.</string>
+            </ArrayOfString>
+          </value>
+        </setting>
+      </TestApp.Properties.Settings>
+    </applicationSettings>
+    <connectionStrings>
+      <add name="FirstConnectionString" connectionString="server=localhost;database=FirstDb;uid=myUser;password=myPass;"/>
+      <add name="SecondConnectionString" connectionString="server=localhost;database=SecondDb;uid=myUser;password=myPass;"/>
+    </connectionStrings>
+  </location>
+  <system.net>
+    <mailSettings>
+      <smtp deliveryMethod="Network" from="someuser@someemailprovidernamehere.com">
+        <network host="localhost" port="25" defaultCredentials="true" />
+      </smtp>
+    </mailSettings>
+  </system.net>
+
+  <system.web>
+    <compilation debug="true"></compilation>
+    <sessionState mode="SQLServer" allowCustomSqlDatabase="true" sqlConnectionString="Data Source=myserver;Initial catalog=ASPState;User ID=aspsession;Password=passwordhere" cookieless="false" timeout="20" stateNetworkTimeout="20"/>
+
+  </system.web>
+</configuration>

--- a/WebDeployParametersToolkit.Tests/WebConfigSample.cs
+++ b/WebDeployParametersToolkit.Tests/WebConfigSample.cs
@@ -35,6 +35,12 @@ namespace WebDeployParametersToolkit.Tests
             ExpectedSettings.Add(setting);
         }
 
+        public static WebConfigSample GetLocationSimpleSettings()
+        {
+            var result = new WebConfigSample(Properties.Resources.LocationSimpleSettings);
+            return result;
+        }
+
         public static WebConfigSample GetSimpleApplicationSettings(ParametersGenerationStyle style)
         {
             var result = new WebConfigSample(Properties.Resources.SimpleSettings);

--- a/WebDeployParametersToolkit.Tests/WebConfigSample.cs
+++ b/WebDeployParametersToolkit.Tests/WebConfigSample.cs
@@ -45,10 +45,10 @@ namespace WebDeployParametersToolkit.Tests
         {
             var result = new WebConfigSample(Properties.Resources.SimpleSettings);
 
-            var appSettingsPathFormat = "/configuration/appSettings/add[@key='{0}']/@value";
+            var appSettingsPathFormat = "/configuration//appSettings/add[@key='{0}']/@value";
             result.AddExpectedApplicationSetting("AppSettingsKey", string.Format(appSettingsPathFormat, "AppSettingsKey"), "0123", style);
 
-            var applicationSettingsPathFormat = "/configuration/applicationSettings/TestApp.Properties.Settings/setting[@name='{0}']/value/text()";
+            var applicationSettingsPathFormat = "/configuration//applicationSettings/TestApp.Properties.Settings/setting[@name='{0}']/value/text()";
             result.AddExpectedApplicationSetting("SomeString", string.Format(applicationSettingsPathFormat, "SomeString"), "String value is here.", style);
             result.AddExpectedApplicationSetting("SomeBoolean", string.Format(applicationSettingsPathFormat, "SomeBoolean"), "True", style);
 

--- a/WebDeployParametersToolkit.Tests/WebConfigSettingsReaderTests.cs
+++ b/WebDeployParametersToolkit.Tests/WebConfigSettingsReaderTests.cs
@@ -113,5 +113,88 @@ namespace WebDeployParametersToolkit.Tests
             var results = WebConfigSettingsReader.ReadSessionStateSettings(emptySettings.Document, ParametersGenerationStyle.Tokenize);
             emptySettings.ExpectedSettings.AssertHasSameItems(results);
         }
+
+
+        #region LocationSimpleSettings
+        [TestMethod]
+        public void ReadApplicationSettingsWithLocationSimpleSettingsReturnsAllTokenized()
+        {
+            var style = ParametersGenerationStyle.Tokenize;
+            var simpleSettings = WebConfigSample.GetSimpleApplicationSettings(style);
+            var locationSimpleSettings = WebConfigSample.GetLocationSimpleSettings();
+            var results = WebConfigSettingsReader.ReadApplicationSettings(locationSimpleSettings.Document, true, true, style);
+            simpleSettings.ExpectedSettings.AssertHasSameItems(results);
+        }
+
+        [TestMethod]
+        public void ReadApplicationSettingsWithLocationSimpleSettingsReturnsAllWithValues()
+        {
+            var style = ParametersGenerationStyle.Clone;
+            var simpleSettings = WebConfigSample.GetSimpleApplicationSettings(style);
+            var locationSimpleSettings = WebConfigSample.GetLocationSimpleSettings();
+            var results = WebConfigSettingsReader.ReadApplicationSettings(locationSimpleSettings.Document, true, true, style);
+            simpleSettings.ExpectedSettings.AssertHasSameItems(results);
+        }
+
+        [TestMethod]
+        public void ReadCompilationDebugSettingsWithLocationSimpleSettingsReturnsTokenized()
+        {
+            var style = ParametersGenerationStyle.Tokenize;
+            var simpleSettings = WebConfigSample.GetSimpleCompilationDebugSettings(style);
+            var locationSimpleSettings = WebConfigSample.GetLocationSimpleSettings();
+            var results = WebConfigSettingsReader.ReadCompilationDebugSettings(locationSimpleSettings.Document, style);
+            simpleSettings.ExpectedSettings.AssertHasSameItems(results);
+        }
+
+        [TestMethod]
+        public void ReadCompilationDebugSettingsWithLocationSimpleSettingsReturnsWithValues()
+        {
+            var style = ParametersGenerationStyle.Clone;
+            var simpleSettings = WebConfigSample.GetSimpleCompilationDebugSettings(style);
+            var locationSimpleSettings = WebConfigSample.GetLocationSimpleSettings();
+            var results = WebConfigSettingsReader.ReadCompilationDebugSettings(locationSimpleSettings.Document, style);
+            simpleSettings.ExpectedSettings.AssertHasSameItems(results);
+        }
+
+        [TestMethod]
+        public void ReadMailSettingsWithLocationSimpleSettingsReturnsAllTokenized()
+        {
+            var style = ParametersGenerationStyle.Tokenize;
+            var simpleSettings = WebConfigSample.GetSimpleMailSettings(style);
+            var locationSimpleSettings = WebConfigSample.GetLocationSimpleSettings();
+            var results = WebConfigSettingsReader.ReadMailSettings(locationSimpleSettings.Document, style);
+            simpleSettings.ExpectedSettings.AssertHasSameItems(results);
+        }
+
+        [TestMethod]
+        public void ReadMailSettingsWithLocationSimpleSettingsReturnsAllWithValues()
+        {
+            var style = ParametersGenerationStyle.Clone;
+            var simpleSettings = WebConfigSample.GetSimpleMailSettings(style);
+            var locationSimpleSettings = WebConfigSample.GetLocationSimpleSettings();
+            var results = WebConfigSettingsReader.ReadMailSettings(locationSimpleSettings.Document, style);
+            simpleSettings.ExpectedSettings.AssertHasSameItems(results);
+        }
+
+        [TestMethod]
+        public void ReadSessionStateSettingsWithLocationSimpleSettingsReturnsAllTokenized()
+        {
+            var style = ParametersGenerationStyle.Tokenize;
+            var simpleSettings = WebConfigSample.GetSimpleSessionStateSettings(style);
+            var locationSimpleSettings = WebConfigSample.GetLocationSimpleSettings();
+            var results = WebConfigSettingsReader.ReadSessionStateSettings(locationSimpleSettings.Document, style);
+            simpleSettings.ExpectedSettings.AssertHasSameItems(results);
+        }
+
+        [TestMethod]
+        public void ReadSessionStateSettingsWithLocationSimpleSettingsReturnsAllWithValues()
+        {
+            var style = ParametersGenerationStyle.Clone;
+            var simpleSettings = WebConfigSample.GetSimpleSessionStateSettings(style);
+            var locationSimpleSettings = WebConfigSample.GetLocationSimpleSettings();
+            var results = WebConfigSettingsReader.ReadSessionStateSettings(locationSimpleSettings.Document, style);
+            simpleSettings.ExpectedSettings.AssertHasSameItems(results);
+        }
+        #endregion
     }
 }

--- a/WebDeployParametersToolkit.Tests/WebDeployParametersToolkit.Tests.csproj
+++ b/WebDeployParametersToolkit.Tests/WebDeployParametersToolkit.Tests.csproj
@@ -68,6 +68,9 @@
     <None Include="Resources\EmptySettings.config">
       <SubType>Designer</SubType>
     </None>
+    <None Include="Resources\LocationSimpleSettings.config">
+      <SubType>Designer</SubType>
+    </None>
     <None Include="Resources\SimpleSettings.config">
       <SubType>Designer</SubType>
     </None>
@@ -76,6 +79,7 @@
     <EmbeddedResource Include="Properties\Resources.resx">
       <Generator>ResXFileCodeGenerator</Generator>
       <LastGenOutput>Resources.Designer.cs</LastGenOutput>
+      <SubType>Designer</SubType>
     </EmbeddedResource>
   </ItemGroup>
   <ItemGroup>

--- a/WebDeployParametersToolkit/Utilities/WebConfigSettingsReader.cs
+++ b/WebDeployParametersToolkit/Utilities/WebConfigSettingsReader.cs
@@ -151,7 +151,7 @@ namespace WebDeployParametersToolkit.Utilities
 
             if (includeAppSettings)
             {
-                var appSettingsPath = "/configuration/appSettings/add";
+                var appSettingsPath = "/configuration/(location|.)/appSettings/add";
                 var appSettingsNodes = document.SelectNodes(appSettingsPath);
                 for (int i = 0; i < appSettingsNodes.Count; i++)
                 {

--- a/WebDeployParametersToolkit/Utilities/WebConfigSettingsReader.cs
+++ b/WebDeployParametersToolkit/Utilities/WebConfigSettingsReader.cs
@@ -151,7 +151,7 @@ namespace WebDeployParametersToolkit.Utilities
 
             if (includeAppSettings)
             {
-                var appSettingsPath = "/configuration/(location|.)/appSettings/add";
+                var appSettingsPath = "/configuration//appSettings/add";
                 var appSettingsNodes = document.SelectNodes(appSettingsPath);
                 for (int i = 0; i < appSettingsNodes.Count; i++)
                 {
@@ -182,7 +182,7 @@ namespace WebDeployParametersToolkit.Utilities
 
             if (includeApplicationSettings)
             {
-                var basePath = "/configuration/applicationSettings";
+                var basePath = "/configuration//applicationSettings";
                 var settingsNode = document.SelectSingleNode(basePath);
 
                 if (settingsNode != null)


### PR DESCRIPTION
Found an issue where our web.config had a "<location>" tag before the actual "<appSettings>".  Apparently this is a valid setup, but this tool doesn't support it out of the box.

With these changes, now it can.  Also added a unit test and modified the unit test setup to accommodate for this change.