### PR TITLE
Update to support VS2022

### DIFF
--- a/WebDeployParametersToolkit/Commands/GenerateSetParametersCommand.cs
+++ b/WebDeployParametersToolkit/Commands/GenerateSetParametersCommand.cs
@@ -166,7 +166,7 @@ namespace WebDeployParametersToolkit
         {
             ThreadHelper.ThrowIfNotOnUIThread();
             var dialog = new FileNameDialog();
-            var hwnd = new IntPtr(VSPackage.DteInstance.MainWindow.HWnd);
+            var hwnd = VSPackage.DteInstance.MainWindow.HWnd;
             var window = (System.Windows.Window)HwndSource.FromHwnd(hwnd).RootVisual;
             dialog.Owner = window;
 

--- a/WebDeployParametersToolkit/WebDeployParametersToolkit.csproj
+++ b/WebDeployParametersToolkit/WebDeployParametersToolkit.csproj
@@ -162,23 +162,23 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Build">
-      <Version>14.3.0</Version>
+      <Version>17.8.3</Version>
     </PackageReference>
-    <PackageReference Include="Microsoft.VisualStudio.SDK" Version="15.0.1" ExcludeAssets="runtime">
+    <PackageReference Include="Microsoft.VisualStudio.SDK" Version="17.8.37222" ExcludeAssets="runtime">
       <IncludeAssets>compile; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.VSSDK.BuildTools" Version="15.9.3039">
+    <PackageReference Include="Microsoft.VSSDK.BuildTools" Version="17.8.2365">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="System.Collections.Immutable">
-      <Version>1.7.0</Version>
+      <Version>8.0.0</Version>
     </PackageReference>
     <PackageReference Include="System.Runtime.CompilerServices.Unsafe">
-      <Version>4.7.1</Version>
+      <Version>6.0.0</Version>
     </PackageReference>
     <PackageReference Include="System.Threading.Tasks.Dataflow">
-      <Version>4.11.0</Version>
+      <Version>8.0.0</Version>
     </PackageReference>
     <PackageReference Include="System.Threading.Tasks.Extensions">
       <Version>4.5.4</Version>

--- a/WebDeployParametersToolkit/source.extension.vsixmanifest
+++ b/WebDeployParametersToolkit/source.extension.vsixmanifest
@@ -12,7 +12,12 @@
         <Tags>SetParameters, WebDeploy, MSDeploy, Parameters</Tags>
     </Metadata>
     <Installation>
-        <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[14.0,17.0]" />
+        <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[14.0,18.0)">
+            <ProductArchitecture>amd64</ProductArchitecture>
+        </InstallationTarget>
+        <InstallationTarget Version="[14.0,18.0)" Id="Microsoft.VisualStudio.Community">
+            <ProductArchitecture>x86</ProductArchitecture>
+        </InstallationTarget>
     </Installation>
     <Dependencies>
         <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.5,)" />


### PR DESCRIPTION
This pull request to the WebDeployParametersToolkit repository includes updates to package references, code improvements, and installation target enhancements. The most important changes include updating package references in the `WebDeployParametersToolkit.csproj` file, removing unnecessary code in the `GenerateSetParametersCommand.cs` file, and adding installation targets for multiple architectures in the `source.extension.vsixmanifest` file.

Main changes:

* <a href="diffhunk://#diff-6d6016041ab1946652d3b0b0826f9d03b8b5ec68989f56c44bf8b03362b80f98L165-R181">`WebDeployParametersToolkit/WebDeployParametersToolkit.csproj`</a>: Updated versions of package references, including `Microsoft.Build`, `Microsoft.VisualStudio.SDK`, and `Microsoft.VSSDK.BuildTools`.
* <a href="diffhunk://#diff-20833d547267e611314c9f9caafab56b29094f0d6abca72cf30c74fcde80cb91L169-R169">`WebDeployParametersToolkit/Commands/GenerateSetParametersCommand.cs`</a>: Removed unnecessary creation of a new `IntPtr` object in the `MenuItemCallback` method.
* <a href="diffhunk://#diff-4625be6ba7b37eb697685d2311daf4d02451c37bdd79c57e161bba16b1a05ca8L15-R20">`WebDeployParametersToolkit/source.extension.vsixmanifest`</a>: Added installation targets for both 64-bit and 32-bit versions of Visual Studio Community in a specific version range.

Resolves #8